### PR TITLE
generate_freeldr_ini: Correctly acquire target file path on Win32

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -210,7 +210,7 @@ bool generate_freeldr_ini(utils_variables *pvariables)
     int i = 0;
     
 #ifdef _WIN32
-    sprintf(temp_path, "%sfreeldr.ini", pvariables->mounted_path);
+    sprintf(temp_path, "%sfreeldr.ini", pvariables->partitions[pvariables->current_partition]);
 #else
     sprintf(temp_path, "%s/freeldr.ini", pvariables->mounted_path);
 #endif


### PR DESCRIPTION
Write freeldr.ini on target USB drive instead of executable path.