### PR TITLE
IsProcessElevated: Fix on Win2k/XP/2k3

### DIFF
--- a/src/build.bat
+++ b/src/build.bat
@@ -1,2 +1,3 @@
 @echo off
-cl /nologo /W3 /O2 /fp:fast /Gm- /Feramdisk-creator.exe main.c gdi.c gui.c utils_win.c tinyfiledialogs.c common.c user32.lib gdi32.lib Advapi32.lib Msimg32.lib Comctl32.lib ComDlg32.lib Ole32.lib Shell32.lib /link /incremental:no
+if %VSCMD_ARG_TGT_ARCH%==x64 (set /a ver_minor = 2) else (set /a ver_minor = 1)
+cl /nologo /W3 /O2 /fp:fast /Gm- /Feramdisk-creator.exe main.c gdi.c gui.c utils_win.c tinyfiledialogs.c common.c user32.lib gdi32.lib Advapi32.lib Msimg32.lib Comctl32.lib ComDlg32.lib Ole32.lib Shell32.lib /link /incremental:no /subsystem:windows,5.%ver_minor%

--- a/src/main.c
+++ b/src/main.c
@@ -2,12 +2,20 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
+    #include <windows.h>
     #include "gdi.h"
 #elif __linux__
     #include "x11.h"
 #endif
 
+#ifdef _WIN32
+int WINAPI WinMain (HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nShowCmd)
+{
+    return start_program();
+}
+#else
 int main()
 {
     return start_program();
 }
+#endif


### PR DESCRIPTION
Fixes a problem with "No Administrator privileges" on Windows 2000/XP/2003 (even when ran as Administrator).
<img width="576" alt="vmplayer_tgw1KRdS09" src="https://user-images.githubusercontent.com/32551254/190924871-3f8bd712-217c-4f4a-bb01-8d9cff71a912.png">
